### PR TITLE
removed size_list() from bplustree

### DIFF
--- a/assignments/11_09_b_plus_tree/bplustree.h
+++ b/assignments/11_09_b_plus_tree/bplustree.h
@@ -49,9 +49,6 @@
 //   std::size_t size()
 //     Postcondition: Returns the total number of items in the leaves.
 //
-//   std::size_t size_list()
-//     Postcondition: Returns the total number of items (in the list) in the tree
-//
 //   Iterator lower_bound(const Item& key)
 //     Postcondition: Returns an iterator pointing to the first element in the
 //     leaves of the BPlusTree that is not less than (i.e. greater or equal to) key.
@@ -217,7 +214,6 @@ public:
   Iterator find(const Item& entry);
   Item& get(const Item& entry);
   std::size_t size();
-  std::size_t size_list();
   Iterator lower_bound(const Item& key);
   Iterator upper_bound(const Item& key);
   Iterator begin();

--- a/assignments/11_10_map/basic_test.cpp
+++ b/assignments/11_10_map/basic_test.cpp
@@ -259,6 +259,7 @@ bool test_multimap(bool debug=false)
   cout << "Other functions" << endl;
   cout << LINE << endl;
   cout << "size():             " << mmap.size() << endl;
+  cout << "size_list():        " << mmap.size_list() << endl;
   cout << "count():            " << mmap.count() << endl;
   cout << "empty():            " << boolalpha << mmap.empty() << endl;
   cout << "mmap.at(20):        " << mmap.at(20) << endl;
@@ -697,6 +698,7 @@ Other functions
 --------------------------------------------------
 
 size():             6
+size_list():        15
 count():            10
 empty():            false
 mmap.at(20):        200 201 203 2500 


### PR DESCRIPTION
this should improve template reusability as size_list() is only used in mmap